### PR TITLE
feat(ci): Add build archive creation for tagged releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,12 +99,18 @@ jobs:
 
           echo "Invalidation completed successfully!"
 
+      - name: Create build archive
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          cd dist
+          zip -r ../build.zip .
+          cd ..
+
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: |
-            dist/**/*
+          files: build.zip
           generate_release_notes: true
           draft: false
           prerelease: false


### PR DESCRIPTION
Create a zip archive of the dist directory when a tag is pushed
Modify GitHub release to upload the single build.zip file instead
Simplify release asset management and improve deployment process